### PR TITLE
do not display auto-save notifications

### DIFF
--- a/home/.SpaceVim.d/autoload/myspacevim.vim
+++ b/home/.SpaceVim.d/autoload/myspacevim.vim
@@ -19,6 +19,7 @@ func! myspacevim#before() abort
   let g:auto_save = 1
   let g:auto_save_no_updatetime = 1
   let g:auto_save_in_insert_mode = 0
+  let g:auto_save_silent = 1
 
   " update with :OmniSharpInstall
   let g:OmniSharp_server_stdio = 1


### PR DESCRIPTION
This also prevent the auto save plugin to overwrite signature information from commands like GoInfo.