### PR TITLE
vim: automaticly detect indentation for files

### DIFF
--- a/home/vim/plugins.vim
+++ b/home/vim/plugins.vim
@@ -9,6 +9,7 @@
             \ ['airblade/vim-gitgutter.git', {'merged' : 0}],
             \ ['tpope/vim-fugitive', {'merged' : 0}],
             \ ['tpope/vim-commentary', {'merged' : 0}],
+            \ ['tpope/vim-sleuth', {'merged' : 0}],
             \ ['chrisbra/Colorizer', {'merged' : 0}],
             \ ['yuttie/comfortable-motion.vim', {'merged' : 0}],
             \ ['HerringtonDarkholme/yats.vim', {'merged' : 0}], 


### PR DESCRIPTION
This plugin sets the indentation options for a buffer based on the file content. So if the files uses tabs, you get tabs. If it uses 4 spaces, you get 4 spaces configured as indentation.