### PR TITLE
feat: set ssh user for analytics server

### DIFF
--- a/home/ssh/config
+++ b/home/ssh/config
@@ -4,3 +4,8 @@ Host *
   # instead of allowing this for all hosts,
   # connect with ssh -A when needed
   # ForwardAgent yes
+Host analytics.prosim-ar.com
+	User lexremote
+	Port 1935
+	Ciphers aes256-ctr
+	ForwardAgent yes


### PR DESCRIPTION
Remove the need to specify port, cipher and username when connecting to the analytics server. This allows us to share the same ssh and scp commands in scripts because they don't need this user specific information anymore.