### PR TITLE
feat: add fzf-up to easily cd to parent directory

### DIFF
--- a/fzf/init.zsh
+++ b/fzf/init.zsh
@@ -19,3 +19,6 @@ zplug "junegunn/fzf",\
 
 # use fzf for completion anywhere after pressing TAB
 zplug "aloxaf/fzf-tab", defer:3
+
+# use CTRL+U to pop fzf widget to select a parent directory
+zplug "pjvds/zsh-fzf-up"

--- a/fzf/init.zsh
+++ b/fzf/init.zsh
@@ -20,5 +20,5 @@ zplug "junegunn/fzf",\
 # use fzf for completion anywhere after pressing TAB
 zplug "aloxaf/fzf-tab", defer:3
 
-# use CTRL+U to pop fzf widget to select a parent directory
+# use ALT+U to pop fzf widget to select a parent directory (set FZF_UP_BINDKEY to override)
 zplug "pjvds/zsh-fzf-up"


### PR DESCRIPTION
This PR adds the fzf-up plugin that enabled easy switching to parent directories.

By default ALT+U is bound to pop an fzf widget to select a parent directory.