### PR TITLE
feat(qutebrowser): add alias to navigate to localhost

### DIFF
--- a/qutebrowser/.config/qutebrowser/autoconfig.yml
+++ b/qutebrowser/.config/qutebrowser/autoconfig.yml
@@ -6,6 +6,9 @@
 
 config_version: 2
 settings:
+  aliases:
+    global:
+      l: open http://localhost:3000
   colors.webpage.bg:
     global: '#282a36'
   colors.webpage.darkmode.enabled:


### PR DESCRIPTION
The `l` alias navigates you to http://localhost:3000.